### PR TITLE
Use a patched zigbuild to address linker errors

### DIFF
--- a/crates/cargo-lambda-build/Cargo.toml
+++ b/crates/cargo-lambda-build/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.58"
 cargo-lambda-interactive.workspace = true
 cargo-lambda-metadata.workspace = true
 cargo-options = "0.5.3"
-cargo-zigbuild = "0.14.5"
+cargo-zigbuild = { git = "https://github.com/WallarooLabs/cargo-zigbuild.git", branch = "fix-linker-error" }
 clap.workspace = true
 home.workspace = true
 miette.workspace = true


### PR DESCRIPTION
See https://github.com/WallarooLabs/cargo-zigbuild/pull/1